### PR TITLE
Support for ctor calls in thread macros

### DIFF
--- a/src/kitchen_async/promise.cljc
+++ b/src/kitchen_async/promise.cljc
@@ -76,7 +76,10 @@
          (kitchen-async.promise/recur ~cond)))))
 
 (defn- interop? [form]
-  (and (symbol? form) (= (nth (name form) 0) \.)))
+  (and (symbol? form)
+       (cc/let [n (name form)]
+         (or (= (first n) \.)     ; member access
+             (= (last n) \.)))))  ; ctor call
 
 (defmacro -> [x & forms]
   (if forms

--- a/test/common/kitchen_async/promise_test.cljs
+++ b/test/common/kitchen_async/promise_test.cljs
@@ -174,6 +174,8 @@
                   (is (= 2 @i))
                   (done))))))
 
+(defrecord R [x])
+
 (deftest ->-test
   (async done
     (p/then (p/-> (p/timeout 0 39)
@@ -192,6 +194,13 @@
               (is (= 42 x))
               (done)))))
 
+(deftest ->-with-ctor-call-test
+  (async done
+    (p/then (p/-> (p/timeout 0 42) R.)
+            (fn [r]
+              (is (= r (->R 42)))
+              (done)))))
+
 (deftest ->>-test
   (async done
     (p/then (p/->> (p/resolve 41)
@@ -208,6 +217,13 @@
                    (- 44))
             (fn [x]
               (is (= 42 x))
+              (done)))))
+
+(deftest ->>-with-ctor-call-test
+  (async done
+    (p/then (p/->> (p/timeout 0 42) R.)
+            (fn [r]
+              (is (= r (->R 42)))
               (done)))))
 
 (deftest some->-non-nil-test
@@ -238,6 +254,13 @@
               (is (= 42 x))
               (done)))))
 
+(deftest some->-with-ctor-call-test
+  (async done
+    (p/then (p/some-> (p/resolve 42) R.)
+            (fn [r]
+              (is (= r (->R 42)))
+              (done)))))
+
 (deftest some->>-non-nil-test
   (async done
     (p/then (p/some->> (p/resolve 1)
@@ -264,6 +287,13 @@
                        (- 44))
             (fn [x]
               (is (= 42 x))
+              (done)))))
+
+(deftest some->>-with-ctor-call-test
+  (async done
+    (p/then (p/some->> (p/resolve 42) R.)
+            (fn [r]
+              (is (= r (->R 42)))
               (done)))))
 
 (deftest try-success-test


### PR DESCRIPTION
Currently, kitchen-async's threading macros poorly support ctor calls:

```clojure
cljs.user=> (require '[kitchen-async.promise :as p])
cljs.user=> (defrecord R [x])
cljs.user=> (p/->> (p/resolve 42) (R.) (prn :r))  ;; this works fine
#object[Promise [object Promise]]
:r #cljs.user.R{:x 42}
cljs.user=> (p/->> (p/resolve 42) R. (prn :r))  ;; but this doesn't
#object[Promise [object Promise]]
:r nil
cljs.user=>
```

This PR fixes them for those cases:

```clojure
cljs.user=> (p/->> (p/resolve 42) R. (prn :r))
#object[Promise [object Promise]]
:r #cljs.user.R{:x 42}
cljs.user=>
```